### PR TITLE
Parse numeric fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ var data = getFormData(form)
 console.log(JSON.stringify(data))
 ```
 ```
-{"product": "1", "quantity": "9", "shipping": "express", "tos": "Y"}
+{"product": "1", "quantity": 9, "shipping": "express", "tos": "Y"}
 ```
 
 ### Getting field data

--- a/src/index.js
+++ b/src/index.js
@@ -161,7 +161,10 @@ function getFormElementValue(element, trim) {
     return value
   }
 
-  if (!CHECKED_INPUT_TYPES[type]) {
+  if (type === 'number') {
+    value = parseInt(element.value, 10)
+  }
+  else if (!CHECKED_INPUT_TYPES[type]) {
     value = (trim ? element.value.replace(TRIM_RE, '') : element.value)
   }
   else if (element.checked) {

--- a/test/index-test.js
+++ b/test/index-test.js
@@ -101,7 +101,7 @@ test('README example - getFormData', t => {
   let data = getFormData(form)
   t.deepEqual(data, {
     product: '1',
-    quantity: '9',
+    quantity: 9,
     shipping: 'express',
     tos: 'Y'
   }, `Data: ${JSON.stringify(data)}`)


### PR DESCRIPTION
This pull requests allows `<input type="number">` fields to be serialized as numeric values, ie. `{ "cost": 50 }` instead of `{ "cost": "500" }`.